### PR TITLE
Add force_dcmread to run_model

### DIFF
--- a/onconet/models/mirai_full.py
+++ b/onconet/models/mirai_full.py
@@ -204,6 +204,7 @@ class MiraiModel:
 
         dcmtk_installed = onconet.utils.dicom.is_dcmtk_installed()
         use_dcmtk = payload.get("dcmtk", True) and dcmtk_installed
+        force_dcmread = payload.get("force_dicom_read", False)
         if use_dcmtk:
             logger.info('Using dcmtk')
         else:
@@ -213,7 +214,7 @@ class MiraiModel:
         dicom_info = {}
         for dicom in dicom_files:
             try:
-                view, side = onconet.utils.dicom.get_dicom_info(pydicom.dcmread(dicom))
+                view, side = onconet.utils.dicom.get_dicom_info(pydicom.dcmread(dicom, force=force_dcmread))
 
                 if (view, side) in dicom_info:
                     prev_dicom = dicom_info[(view, side)]
@@ -246,7 +247,7 @@ class MiraiModel:
                     logger.debug('Image mode from dcmtk: {}'.format(image.mode))
                     images.append({'x': image, 'side_seq': side, 'view_seq': view})
                 else:
-                    dicom = pydicom.dcmread(dicom_path)
+                    dicom = pydicom.dcmread(dicom_path, force=force_dcmread)
                     image = onconet.utils.dicom.dicom_to_arr(dicom, pillow=True)
                     logger.debug('Image mode from dicom: {}'.format(image.mode))
                     images.append({'x': image, 'side_seq': side, 'view_seq': view})


### PR DESCRIPTION
Adds possibility of force_dicom_read to the model runtime arguments input for mirai_full model runtime to toggle the "force" argument for pydicom's dcmread method. This will allow users/deploying developers to allow for non-compliant DICOM's to be loaded depending on environment.