### PR TITLE
Alternative manufacturers preprocessing

### DIFF
--- a/onconet/utils/dicom.py
+++ b/onconet/utils/dicom.py
@@ -201,10 +201,19 @@ def get_dicom_info(dicom: pydicom.Dataset):
         int: binary integer 0 or 1 corresponding to the type of View Position
         int: binary integer 0 or 1 corresponding to the type of Image Laterality
     """
-    if not hasattr(dicom, 'ViewPosition'):
-        raise AttributeError('ViewPosition does not exist in DICOM metadata')
 
-    view_str = dicom.ViewPosition
+    # Some cases (FUJIFILM) have cases where view position is in
+    # Acquisition Device Processing Description (0018, 1400)
+    # rather than standard DICOM tag
+    if not hasattr(dicom, 'ViewPosition'):
+        if 'CC' in dicom[0x0018, 0x1400].value:  # Acquisition Device Processing Description
+            view_str = 'CC'
+        elif 'MLO' in dicom[0x0018, 0x1400].value:
+            view_str = 'MLO'
+        else:
+            raise AttributeError('ViewPosition does not exist in DICOM metadata')
+    else:
+        view_str = dicom.ViewPosition
 
     # Have seen cases where ImageLaterality is not present in DICOM metadata,
     # and the relevant information is in the ViewPosition tag. Check for this.


### PR DESCRIPTION
Defining dicom_to_arr_pydicom as an alternative to dicom_to_arr using pydicom's builtin function apply_voi_lut. It seems to result in the same images as dicom_to_arr for Hologic, GE Healthcare, Siemens images. For other manufacturers (Giotto, Metaltronica, FUJIFILM and PLanmed), it reads the voi function and applies the transformation specified in their DICOM tags. It also includes support for FUJIFILM and Planmed images that are reversed.

May need some further testing.